### PR TITLE
Gzip stream handling

### DIFF
--- a/ReadMe.Md
+++ b/ReadMe.Md
@@ -12,7 +12,7 @@ Achuta! Jabba is a json friendly reverse proxy for micro-services, written in go
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Features
-* HTTP 1.1 compatible reverse proxy w/ TLS support.
+* HTTP 1.1 compatible buffering reverse proxy w/ TLS support.
 * JSON API friendly, configurable recovery of idempotent requests.
 * policy based routing to multiple upstream servers for a/b testing
 * highly concurrent with multiprocessor support, 10k req/s

--- a/gzip.go
+++ b/gzip.go
@@ -3,17 +3,27 @@ package jabba
 import (
 	"bytes"
 	"compress/gzip"
+	"io/ioutil"
 	"sync"
 
 	"github.com/rs/zerolog/log"
 )
 
 var gzipMagicBytes = []byte{0x1f, 0x8b}
+var gzipSmall = []byte{31,139,8,0,0,0,0,0,0,255,170,174,5,4,0,0,255,255,67,191,166,163,2,0,0,0}
 
 var zipPool = sync.Pool{
 	New: func() interface{} {
 		var buf bytes.Buffer
 		return gzip.NewWriter(&buf)
+	},
+}
+
+var unzipPool = sync.Pool{
+	New: func() interface{} {
+		buf := bytes.NewBuffer(gzipSmall)
+		r, _ := gzip.NewReader(buf)
+		return r
 	},
 }
 
@@ -23,11 +33,25 @@ func Gzip(input []byte) []byte {
 	buf := &bytes.Buffer{}
 	wrt.Reset(buf)
 
-	wrt.Write(input)
-	wrt.Close()
+	_, _ = wrt.Write(input)
+	_ = wrt.Close()
 	defer zipPool.Put(wrt)
 
 	enc := buf.Bytes()
-	log.Trace().Msgf("byte buffer size %d", len(enc))
+	log.Trace().Msgf("zipped byte buffer size %d", len(enc))
 	return enc
+}
+
+// Gunzip a []byte
+func Gunzip(input []byte) []byte {
+	rd, _ := unzipPool.Get().(*gzip.Reader)
+	buf := bytes.NewBuffer(input)
+	_ = rd.Reset(buf)
+
+	dec, _ := ioutil.ReadAll(rd)
+	_ = rd.Close()
+	defer unzipPool.Put(rd)
+
+	log.Trace().Msgf("unzipped byte buffer size %d", len(dec))
+	return dec
 }

--- a/gzip_test.go
+++ b/gzip_test.go
@@ -2,10 +2,11 @@ package jabba
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
-//TestDefaultDownstreamReadTimeout
+//test pool allocation of zipper
 func TestGzipper(t *testing.T) {
 	//run small loop to ensure pool allocation works
 	for i:=0;i<=10;i++ {
@@ -19,6 +20,15 @@ func TestGzipper(t *testing.T) {
 		var want = [2]int{100, 120}
 		if !(len(zipped) >= want[0] && len(zipped) <= want[1]) {
 			t.Errorf("gzip compression not working")
+		}
+	}
+}
+
+func TestGzipThenUnzip(t *testing.T) {
+	for i:=0;i<=100;i++ {
+		json := []byte(fmt.Sprintf(`{ "key":"value%d" }`, i))
+		if c := bytes.Compare(json, Gunzip(Gzip(json))); c != 0 {
+			t.Error("unzipped data is not equal to original")
 		}
 	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -169,3 +169,7 @@ func (proxy *Proxy) hasLegalHTTPMethod() bool {
 func (proxy *Proxy) shouldGzipEncodeResponseBody() bool {
 	return proxy.Dwn.Resp.SendGzip && !proxy.Up.Atmpt.isGzip
 }
+
+func (proxy *Proxy) shouldGzipDecodeResponseBody() bool {
+	return !proxy.Dwn.Resp.SendGzip && proxy.Up.Atmpt.isGzip
+}

--- a/proxyhandler.go
+++ b/proxyhandler.go
@@ -19,7 +19,7 @@ const contentEncoding = "Content-Encoding"
 var httpClient HTTPClient
 
 //httpResponseHeadersNoRewrite contains a list of headers that are not copied from upstream to downstream to avoid bugs.
-var httpResponseHeadersNoRewrite []string = []string{"Date", "Content-Length"}
+var httpResponseHeadersNoRewrite []string = []string{"Date", "Content-Length", "Content-Encoding"}
 
 // main proxy handling
 func proxyHandler(response http.ResponseWriter, request *http.Request) {
@@ -92,6 +92,7 @@ func handle(proxy *Proxy) {
 			writeStandardResponseHeaders(proxy)
 			copyUpstreamResponseHeaders(proxy, upstreamResponse)
 			resetContentLengthHeader(proxy, upstreamResponseBody)
+			setContentEncodingHeader(proxy, upstreamResponse)
 			writeStatusCodeHeader(proxy.respondWith(upstreamResponse.StatusCode, "none"))
 			copyUpstreamResponseBody(proxy, upstreamResponseBody)
 			logHandledRequest(proxy)
@@ -129,6 +130,17 @@ func resetContentLengthHeader(proxy *Proxy, upstreamResponseBody []byte) {
 	}
 }
 
+func setContentEncodingHeader(proxy *Proxy, upstreamResponse *http.Response) {
+	if proxy.Dwn.Resp.SendGzip {                                   //we still need this func for sending std response.
+		proxy.Dwn.Resp.Writer.Header().Set("Content-Encoding", proxy.contentEncoding())
+	} else {
+		ce := upstreamResponse.Header["Content-Encoding"]
+		if len(ce) > 0 {
+			proxy.Dwn.Resp.Writer.Header().Set("Content-Encoding", strings.Join(ce, " "))
+		}
+	}
+}
+
 func copyUpstreamResponseBody(proxy *Proxy, upstreamResponseBody []byte) {
 	start := time.Now()
 	if proxy.shouldGzipEncodeResponseBody() {
@@ -147,9 +159,6 @@ func copyUpstreamResponseHeaders(proxy *Proxy, upstreamResponse *http.Response) 
 			for _, mval := range values {
 				proxy.Dwn.Resp.Writer.Header().Set(key, mval)
 			}
-		}
-		if key == contentEncoding {
-			proxy.Up.Atmpt.isGzip = proxy.Up.Atmpt.isGzip || strings.Contains(strings.Join(values, " "), "gzip")
 		}
 	}
 }

--- a/proxyhandler.go
+++ b/proxyhandler.go
@@ -19,7 +19,7 @@ const contentEncoding = "Content-Encoding"
 var httpClient HTTPClient
 
 //httpResponseHeadersNoRewrite contains a list of headers that are not copied from upstream to downstream to avoid bugs.
-var httpResponseHeadersNoRewrite []string = []string{"Date", "Content-Length", "Content-Encoding"}
+var httpResponseHeadersNoRewrite []string = []string{"Date", "Content-Length", contentEncoding}
 
 // main proxy handling
 func proxyHandler(response http.ResponseWriter, request *http.Request) {

--- a/proxyhandler_test.go
+++ b/proxyhandler_test.go
@@ -133,7 +133,7 @@ func TestUpstreamIdentityEncodingPassThrough(t *testing.T) {
 	}
 }
 
-func TestUpstreamIdentityEncodingPassThroughWithBadAcceptEncoding(t *testing.T) {
+func TestUpstreamCustomEncodingPassThroughWithBadAcceptEncoding(t *testing.T) {
 	Runner = mockRuntime()
 	httpClient = &MockHttp{}
 	mockDoFunc = func(req *http.Request) (*http.Response, error) {
@@ -141,7 +141,7 @@ func TestUpstreamIdentityEncodingPassThroughWithBadAcceptEncoding(t *testing.T) 
 		return &http.Response{
 			StatusCode: 200,
 			Header: map[string][]string{
-				"Content-Encoding": []string{"identity"},
+				"Content-Encoding": []string{"custom"},
 			},
 			Body: ioutil.NopCloser(bytes.NewReader([]byte(json))),
 		}, nil
@@ -163,7 +163,7 @@ func TestUpstreamIdentityEncodingPassThroughWithBadAcceptEncoding(t *testing.T) 
 		t.Errorf("body should not have gzip response magic bytes: %v", gotBody[0:2])
 	}
 
-	want := "identity"
+	want := "custom"
 	got := resp.Header["Content-Encoding"][0]
 	if got != want {
 		t.Errorf("uh oh, did not receive correct Content-Encoding header, want %v, got %v", want, got)

--- a/proxyhandler_test.go
+++ b/proxyhandler_test.go
@@ -72,10 +72,8 @@ func TestUpstreamGzipEncodingPassThroughWithProxyHandler(t *testing.T) {
 		}, nil
 	}
 
-	h := &TestHttpHandler{}
-	server := httptest.NewServer(h)
+	server := httptest.NewServer(&TestHttpHandler{})
 	defer server.Close()
-
 	resp, err := http.Get(server.URL)
 	if err != nil {
 		t.Fatal(err)

--- a/proxyhandler_test.go
+++ b/proxyhandler_test.go
@@ -172,7 +172,7 @@ func TestUpstreamCustomEncodingPassThroughWithBadAcceptEncoding(t *testing.T) {
 	}
 }
 
-
+// mocks upstream response with custom encoding that is passed through to client that accepts identity
 func TestUpstreamCustomEncodingPassThroughWithIdentityAcceptEncoding(t *testing.T) {
 	Runner = mockRuntime()
 	httpClient = &MockHttp{}
@@ -242,6 +242,44 @@ func TestUpstreamGzipReEncodingWithProxyHandler(t *testing.T) {
 	}
 
 	want := "gzip"
+	got := resp.Header["Content-Encoding"][0]
+	if got != want {
+		t.Errorf("uh oh, did not receive correct Content-Encoding header, want %v, got %v", want, got)
+	}
+}
+
+// mocks upstream gzip that is re-decoded as identity by Jabba
+func TestUpstreamGzipReDecodingWithProxyHandler(t *testing.T) {
+	Runner = mockRuntime()
+	httpClient = &MockHttp{}
+	mockDoFunc = func(req *http.Request) (*http.Response, error) {
+		json := `{"key":"value"}`
+		return &http.Response{
+			StatusCode: 200,
+			Header: map[string][]string{
+				"Content-Encoding": []string{"gzip"},
+			},
+			Body: ioutil.NopCloser(bytes.NewReader(Gzip([]byte(json)))),
+		}, nil
+	}
+
+	server := httptest.NewServer(&ProxyHttpHandler{})
+	defer server.Close()
+
+	c := &http.Client{}
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	req.Header.Set("Accept-Encoding", "identity")
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotBody, _ := ioutil.ReadAll(resp.Body)
+	if c := bytes.Compare(gotBody[0:2], gzipMagicBytes); c == 0 {
+		t.Errorf("body should not have gzip response magic bytes, got %v", gotBody[0:2])
+	}
+
+	want := "identity"
 	got := resp.Header["Content-Encoding"][0]
 	if got != want {
 		t.Errorf("uh oh, did not receive correct Content-Encoding header, want %v, got %v", want, got)

--- a/proxyhandler_test.go
+++ b/proxyhandler_test.go
@@ -25,13 +25,13 @@ func (m *MockHttp) Get(uri string) (*http.Response, error) {
 }
 
 //this testHandler binds the mock HTTP server to proxyHandler.
-type TestHttpHandler struct{}
+type ProxyHttpHandler struct{}
 
-func (t TestHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (t ProxyHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	proxyHandler(w, r)
 }
 
-// TestUpstreamSuccessWithProxyHandler mocks a 200 upstream response and tests the proxy handler returns clean.
+// mocks a 200 upstream response and tests the proxy handler returns clean.
 func TestUpstreamSuccessWithProxyHandler(t *testing.T) {
 	Runner = mockRuntime()
 	httpClient = &MockHttp{}
@@ -43,7 +43,7 @@ func TestUpstreamSuccessWithProxyHandler(t *testing.T) {
 		}, nil
 	}
 
-	h := &TestHttpHandler{}
+	h := &ProxyHttpHandler{}
 	server := httptest.NewServer(h)
 	defer server.Close()
 
@@ -58,6 +58,7 @@ func TestUpstreamSuccessWithProxyHandler(t *testing.T) {
 	}
 }
 
+// mocks upstream identity response that is re-encoded as gzip by Jabba
 func TestUpstreamGzipEncodingPassThroughWithProxyHandler(t *testing.T) {
 	Runner = mockRuntime()
 	httpClient = &MockHttp{}
@@ -72,7 +73,44 @@ func TestUpstreamGzipEncodingPassThroughWithProxyHandler(t *testing.T) {
 		}, nil
 	}
 
-	server := httptest.NewServer(&TestHttpHandler{})
+	server := httptest.NewServer(&ProxyHttpHandler{})
+	defer server.Close()
+
+	c := &http.Client{}
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotBody, _ := ioutil.ReadAll(resp.Body)
+	if c := bytes.Compare(gotBody[0:2], gzipMagicBytes); c != 0 {
+		t.Errorf("uh, oh, body did not have gzip response magic bytes, want %v, got %v", gzipMagicBytes, gotBody[0:2])
+	}
+
+	want := "gzip"
+	got := resp.Header["Content-Encoding"][0]
+	if got != want {
+		t.Errorf("uh oh, did not receive correct Content-Encoding header, want %v, got %v", want, got)
+	}
+}
+
+func TestUpstreamGzipReEncodingWithProxyHandler(t *testing.T) {
+	Runner = mockRuntime()
+	httpClient = &MockHttp{}
+	mockDoFunc = func(req *http.Request) (*http.Response, error) {
+		json := `{"key":"value"}`
+		return &http.Response{
+			StatusCode: 200,
+			Header: map[string][]string{
+				"Content-Encoding": []string{"identity"},
+			},
+			Body: ioutil.NopCloser(bytes.NewReader([]byte(json))),
+		}, nil
+	}
+
+	server := httptest.NewServer(&ProxyHttpHandler{})
 	defer server.Close()
 
 	c := &http.Client{}
@@ -109,7 +147,7 @@ func TestUpstreamHeadersAreRewrittenWithProxyHandler(t *testing.T) {
 		}, nil
 	}
 
-	h := &TestHttpHandler{}
+	h := &ProxyHttpHandler{}
 	server := httptest.NewServer(h)
 	defer server.Close()
 
@@ -136,7 +174,7 @@ func TestUpstreamPOSTNonRetryWithProxyHandler(t *testing.T) {
 		}, nil
 	}
 
-	h := &TestHttpHandler{}
+	h := &ProxyHttpHandler{}
 	server := httptest.NewServer(h)
 	defer server.Close()
 
@@ -164,7 +202,7 @@ func TestUpstreamGETRetryWithProxyHandler(t *testing.T) {
 		}, nil
 	}
 
-	h := &TestHttpHandler{}
+	h := &ProxyHttpHandler{}
 	server := httptest.NewServer(h)
 	defer server.Close()
 

--- a/responses.go
+++ b/responses.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"math/rand"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -56,5 +57,18 @@ func randomHuttese() string {
 }
 
 func aboutHandler(w http.ResponseWriter, r *http.Request) {
-	w.Write(AboutResponse{}.AsJSON())
+	ae := r.Header["Accept-Encoding"]
+	if len(ae) > 0 {
+		s := strings.Join(ae, " ")
+		if strings.Contains(s, "gzip") {
+			w.Header().Set("Content-Encoding", "gzip")
+			w.Write(Gzip(AboutResponse{}.AsJSON()))
+		} else {
+			w.Header().Set("Content-Encoding", "identity")
+			w.Write(AboutResponse{}.AsJSON())
+		}
+	} else {
+		w.Header().Set("Content-Encoding", "identity")
+		w.Write(AboutResponse{}.AsJSON())
+	}
 }

--- a/responses_test.go
+++ b/responses_test.go
@@ -1,0 +1,68 @@
+package jabba
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+//this testHandler binds the mock HTTP server to proxyHandler.
+type AboutHttpHandler struct{}
+
+func (t AboutHttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	aboutHandler(w, r)
+}
+
+func TestAboutHandlerContentEncodingIdentity(t *testing.T) {
+	Runner = mockRuntime()
+
+	server := httptest.NewServer(&AboutHttpHandler{})
+	defer server.Close()
+
+	c := &http.Client{}
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	req.Header.Set("Accept-Encoding", "identity")
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotBody, _ := ioutil.ReadAll(resp.Body)
+	if c := bytes.Compare(gotBody[0:2], gzipMagicBytes); c == 0 {
+		t.Errorf("body should not have gzip response magic bytes but does: %v", gotBody[0:2])
+	}
+
+	want := "identity"
+	got := resp.Header["Content-Encoding"][0]
+	if got != want {
+		t.Errorf("response does have correct Content-Encoding header, want %v, got %v", want, got)
+	}
+}
+
+func TestAboutHandlerContentEncodingGzip(t *testing.T) {
+	Runner = mockRuntime()
+
+	server := httptest.NewServer(&AboutHttpHandler{})
+	defer server.Close()
+
+	c := &http.Client{}
+	req, _ := http.NewRequest("GET", server.URL, nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotBody, _ := ioutil.ReadAll(resp.Body)
+	if c := bytes.Compare(gotBody[0:2], gzipMagicBytes); c != 0 {
+		t.Errorf("body should not have gzip response magic bytes but does: %v", gotBody[0:2])
+	}
+
+	want := "gzip"
+	got := resp.Header["Content-Encoding"][0]
+	if got != want {
+		t.Errorf("response does have correct Content-Encoding header, want %v, got %v", want, got)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -128,6 +128,7 @@ func sendStatusCodeAsJSON(proxy *Proxy) {
 	}
 	writeStandardResponseHeaders(proxy)
 	proxy.Dwn.Resp.Writer.Header().Set("Content-Type", "application/json")
+	proxy.Dwn.Resp.Writer.Header().Set("Content-Encoding", proxy.contentEncoding())
 
 	proxy.Dwn.Resp.Writer.WriteHeader(proxy.Dwn.Resp.StatusCode)
 
@@ -136,6 +137,7 @@ func sendStatusCodeAsJSON(proxy *Proxy) {
 		Message:    proxy.Dwn.Resp.Message,
 		XRequestID: proxy.XRequestID,
 	}
+
 	if proxy.Dwn.Resp.SendGzip {
 		proxy.Dwn.Resp.Writer.Write(Gzip(statusCodeResponse.AsJSON()))
 	} else {

--- a/server.go
+++ b/server.go
@@ -104,7 +104,6 @@ func writeStandardResponseHeaders(proxy *Proxy) {
 	header := proxy.Dwn.Resp.Writer.Header()
 
 	header.Set("Server", fmt.Sprintf("Jabba %s %s", Version, ID))
-	header.Set("Content-Encoding", proxy.contentEncoding())
 	header.Set("Cache-control:", "no-store, no-cache, must-revalidate, proxy-revalidate")
 	//for TLS response, we set HSTS header see RFC6797
 	if Runner.Connection.Downstream.Mode == "TLS" {

--- a/server.go
+++ b/server.go
@@ -12,7 +12,7 @@ import (
 )
 
 //Version is the server version
-var Version string = "v0.3.6"
+var Version string = "v0.3.7"
 
 //ID is a unique server ID
 var ID string = "unknown"


### PR DESCRIPTION
- bumped to 0.3.7
- gzip decoding with additional test
- added unzipper with test
- test upstream content encoding passed through when identity requested
- custom encoding
- testing bad accept-encoding
- test gzip encoding
- bug in test, did not properly set accept-encoding header causes response to fail
- Update ReadMe.Md
- added gzip response for about handler
- setting content encoding header for std responses
- new behaviour for content-encoding, see: https://github.com/simonmittag/jabba/issues/10
